### PR TITLE
Replaced all includes of log4cxx/ with log4cxxNG/

### DIFF
--- a/src/examples/cpp/console.cpp
+++ b/src/examples/cpp/console.cpp
@@ -18,10 +18,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <log4cxx/logger.h>
-#include <log4cxx/consoleappender.h>
-#include <log4cxx/simplelayout.h>
-#include <log4cxx/logmanager.h>
+#include <log4cxxNG/logger.h>
+#include <log4cxxNG/consoleappender.h>
+#include <log4cxxNG/simplelayout.h>
+#include <log4cxxNG/logmanager.h>
 #include <iostream>
 #include <locale.h>
 #include <cstring>

--- a/src/examples/cpp/delayedloop.cpp
+++ b/src/examples/cpp/delayedloop.cpp
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-#include <log4cxx/logger.h>
-#include <log4cxx/xml/domconfigurator.h>
-#include <log4cxx/propertyconfigurator.h>
+#include <log4cxxNG/logger.h>
+#include <log4cxxNG/xml/domconfigurator.h>
+#include <log4cxxNG/propertyconfigurator.h>
 #include <apr_general.h>
 #include <apr_time.h>
 #include <iostream>
-#include <log4cxx/stream.h>
+#include <log4cxxNG/stream.h>
 #include <exception>
 #include <stdlib.h>
 

--- a/src/examples/cpp/stream.cpp
+++ b/src/examples/cpp/stream.cpp
@@ -16,10 +16,10 @@
  */
 
 #include <stdlib.h>
-#include <log4cxx/stream.h>
-#include <log4cxx/basicconfigurator.h>
-#include <log4cxx/helpers/exception.h>
-#include <log4cxx/ndc.h>
+#include <log4cxxNG/stream.h>
+#include <log4cxxNG/basicconfigurator.h>
+#include <log4cxxNG/helpers/exception.h>
+#include <log4cxxNG/ndc.h>
 #include <locale.h>
 
 using namespace log4cxx;

--- a/src/examples/cpp/trivial.cpp
+++ b/src/examples/cpp/trivial.cpp
@@ -14,12 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <log4cxx/logstring.h>
+#include <log4cxxNG/logstring.h>
 #include <stdlib.h>
-#include <log4cxx/logger.h>
-#include <log4cxx/basicconfigurator.h>
-#include <log4cxx/helpers/exception.h>
-#include <log4cxx/ndc.h>
+#include <log4cxxNG/logger.h>
+#include <log4cxxNG/basicconfigurator.h>
+#include <log4cxxNG/helpers/exception.h>
+#include <log4cxxNG/ndc.h>
 #include <locale.h>
 
 using namespace log4cxx;

--- a/src/main/cpp/threadlocal.cpp
+++ b/src/main/cpp/threadlocal.cpp
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include "log4cxx/helpers/threadlocal.h"
+#include "log4cxxNG/helpers/threadlocal.h"
 #include "apr_thread_proc.h"
-#include "log4cxx/helpers/exception.h"
+#include "log4cxxNG/helpers/exception.h"
 
 using namespace log4cxx::helpers;
 using namespace log4cxx;

--- a/src/main/include/log4cxxNG/config/propertysetter.h
+++ b/src/main/include/log4cxxNG/config/propertysetter.h
@@ -18,8 +18,8 @@
 #ifndef _LOG4CXX_CONFIG_PROPERTYSETTER_H
 #define _LOG4CXX_CONFIG_PROPERTYSETTER_H
 
-#include <log4cxx/logstring.h>
-#include <log4cxx/helpers/objectptr.h>
+#include <log4cxxNG/logstring.h>
+#include <log4cxxNG/helpers/objectptr.h>
 
 namespace log4cxx
 {


### PR DESCRIPTION
Using `log4cxxNG` instead of `log4cxx` as include path in every source and header files, as the latter no longer exists.